### PR TITLE
Use ClassUtils from Doctrine into Aggregator constructor to avoid having Proxy into Algolia

### DIFF
--- a/src/Model/Aggregator.php
+++ b/src/Model/Aggregator.php
@@ -6,6 +6,7 @@ use Algolia\SearchBundle\Exception\EntityNotFoundInObjectID;
 use Algolia\SearchBundle\Exception\InvalidEntityForAggregator;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Doctrine\Common\Util\ClassUtils;
 
 abstract class Aggregator implements NormalizableInterface
 {
@@ -38,7 +39,7 @@ abstract class Aggregator implements NormalizableInterface
             throw new InvalidEntityForAggregator("Aggregators don't support more than one primary key.");
         }
 
-        $this->objectID = get_class($this->entity) . '::' . reset($entityIdentifierValues);
+        $this->objectID = ClassUtils::getClass($this->entity) . '::' . reset($entityIdentifierValues);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #339
| Need Doc update   | no


## Describe your change

Instead of using `get_class` use the `ClassUtils` from doctrine project to replace Proxy class to real class.

## What problem is this fixing?

https://github.com/algolia/search-bundle/issues/339
